### PR TITLE
Prevent silent fail-open in duramen-hook.sh script via jq pure-shell fallbacks

### DIFF
--- a/hooks/copilot-cli/duramen-hook.sh
+++ b/hooks/copilot-cli/duramen-hook.sh
@@ -2,6 +2,13 @@
 # duramen pre-tool-use hook for Copilot CLI
 # Reads tool call payload from stdin, evaluates via duramen, returns permission decision.
 
+# Verify that jq exists and has not been tampered with before running the script.
+# A missing or malformed jq command could lead to a silent bypass of the policy engine.
+if ! command -v jq >/dev/null 2>&1; then
+  echo '{"permissionDecision":"deny","permissionDecisionReason":"Duramen hook: jq not found (fail-closed)"}'
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Use local binary if present, otherwise fall back to PATH

--- a/hooks/copilot-cli/duramen-hook.sh
+++ b/hooks/copilot-cli/duramen-hook.sh
@@ -2,12 +2,18 @@
 # duramen pre-tool-use hook for Copilot CLI
 # Reads tool call payload from stdin, evaluates via duramen, returns permission decision.
 
-# Verify that jq exists and has not been tampered with before running the script.
+# Verify that jq exists AND responds to a basic flag (Integrity check)
 # A missing or malformed jq command could lead to a silent bypass of the policy engine.
-if ! command -v jq >/dev/null 2>&1; then
-  echo '{"permissionDecision":"deny","permissionDecisionReason":"Duramen hook: jq not found (fail-closed)"}'
+if ! command -v jq >/dev/null 2>&1 || ! jq --version >/dev/null 2>&1; then
+  echo '{"permissionDecision":"deny","permissionDecisionReason":"Duramen hook: valid jq not found (fail-closed)"}'
   exit 1
 fi
+
+# Pure-shell fallback for JSON construction
+# Escapes backslashes, double quotes, and tabs safely without jq
+safe_json_reason() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | tr -d '\n'
+}
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -29,9 +35,12 @@ case $EXIT_CODE in
     echo '{"permissionDecision": "allow"}'
     ;;
   1)
-    POLICY_NAME=$(echo "$RESULT" | jq -r '.policy_name // empty')
-    POLICY_DESC=$(echo "$RESULT" | jq -r '.policy_description // empty')
-    REASON=$(echo "$RESULT" | jq -r '.message // "Blocked by policy"')
+    # If jq is broken here, these simply become empty strings, which is safe.
+    POLICY_NAME=$(echo "$RESULT" | jq -r '.policy_name // empty' 2>/dev/null)
+    POLICY_DESC=$(echo "$RESULT" | jq -r '.policy_description // empty' 2>/dev/null)
+    REASON=$(echo "$RESULT" | jq -r '.message // empty' 2>/dev/null)
+    [ -z "$REASON" ] && REASON="Blocked by policy"
+
     if [ -n "$POLICY_NAME" ]; then
       REASON="$REASON [$POLICY_NAME"
       if [ -n "$POLICY_DESC" ]; then
@@ -39,12 +48,17 @@ case $EXIT_CODE in
       fi
       REASON="$REASON]"
     fi
-    jq -n --arg reason "$REASON" '{"permissionDecision":"deny","permissionDecisionReason":$reason}'
+
+    # Try jq first, fallback to pure-shell construction if jq fails/is removed mid-execution
+    jq -n --arg reason "$REASON" '{"permissionDecision":"deny","permissionDecisionReason":$reason}' 2>/dev/null || \
+      echo "{\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"$(safe_json_reason "$REASON")\"}"
     ;;
   2)
-    POLICY_NAME=$(echo "$RESULT" | jq -r '.policy_name // empty')
-    POLICY_DESC=$(echo "$RESULT" | jq -r '.policy_description // empty')
-    REASON=$(echo "$RESULT" | jq -r '.message // "Requires approval"')
+    POLICY_NAME=$(echo "$RESULT" | jq -r '.policy_name // empty' 2>/dev/null)
+    POLICY_DESC=$(echo "$RESULT" | jq -r '.policy_description // empty' 2>/dev/null)
+    REASON=$(echo "$RESULT" | jq -r '.message // empty' 2>/dev/null)
+    [ -z "$REASON" ] && REASON="Requires approval"
+
     if [ -n "$POLICY_NAME" ]; then
       REASON="$REASON [$POLICY_NAME"
       if [ -n "$POLICY_DESC" ]; then
@@ -52,7 +66,10 @@ case $EXIT_CODE in
       fi
       REASON="$REASON]"
     fi
-    jq -n --arg reason "$REASON" '{"permissionDecision":"ask","permissionDecisionReason":$reason}'
+
+    # Try jq first, fallback to pure-shell construction if jq fails/is removed mid-execution
+    jq -n --arg reason "$REASON" '{"permissionDecision":"ask","permissionDecisionReason":$reason}' 2>/dev/null || \
+      echo "{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"$(safe_json_reason "$REASON")\"}"
     ;;
   *)
     # Fail-closed on system errors — security systems must never fail-open


### PR DESCRIPTION
## Summary
This pull request improves the resilience of the Copilot CLI pre-tool-use hook (`duramen-hook.sh`). It addresses a potential vulnerability where a missing, malformed, or maliciously removed `jq` binary could cause the script to fail silently. This silent failure would result in zero output for "deny" or "ask" decisions, potentially causing the calling application to fail-open and bypass Duramen's policy engine.

## Changes
- Added an initial integrity check at script startup (`command -v jq` and `jq --version`) to ensure `jq` exists and is functional, fail-closing immediately if it is tampered with or missing.
- Introduced a pure-shell fallback function (`safe_json_reason`) to safely escape strings (backslashes, quotes, tabs) for JSON construction without relying on external binaries.
- Refactored `POLICY_NAME`, `POLICY_DESC`, and `REASON` variable assignments to safely catch `jq` failures (`2>/dev/null`) and apply default values using pure Bash.
- Implemented pure-Bash fallback JSON construction (`|| echo "{...}"`) for both the `deny` (exit 1) and `ask` (exit 2) paths to guarantee valid output even if `jq` is compromised mid-execution.

## Why
Security systems must never fail-open. Because AI agents can execute commands in the background, this script was vulnerable to Time-Of-Check to Time-Of-Use (TOCTOU) race conditions and `$PATH` shadowing. If an agent disabled or replaced `jq` mid-execution, the final `jq -n` command would silently fail, producing no output and effectively dropping the "deny" decision. By implementing pure-shell fallbacks, we guarantee that Duramen strictly outputs valid JSON to block unauthorized actions, completely neutralizing environment-manipulation attacks against `jq`.

## Verification (via WSL)
- **Verified Standard Path:** Script returns standard Duramen output when `jq` is healthy.
- **Verified Missing Dependency:** Simulated missing `jq` via empty `$PATH`. Script immediately fail-closed with `valid jq not found`.
- **Verified Race-Condition / Integrity Failure:** Supplied a fake `jq` binary that passes version checks but fails during execution. Confirmed the pure-bash fallbacks successfully caught the failure, applied default reasoning ("Blocked by policy"), and returned strictly formatted `deny` JSON payloads.
