### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Fine-grained authorization for AI coding agents, powered by Cedar"
-repository = "https://github.com/anthropics/duramen"
+repository = "https://github.com/kanggui/Duramen"
 
 [workspace.dependencies]
 cedar-policy = "4"


### PR DESCRIPTION
## Summary
This pull request corrects the package metadata in `Cargo.toml` by updating the repository URL to point to the correct upstream repository.

## Changes
- Updated the `repository` field in `Cargo.toml` from `https://github.com/anthropics/duramen` to `https://github.com/kanggui/Duramen`.

## Why
Credit where credit is due, seems like Claude injected Anthropic's name to repository URL 😄 
This updates the metadata to reflect the true home of the project so that `crates.io` and other Rust tooling direct users to the right place.

## Verification
- Visually verified the change in `Cargo.toml`.

