### PR TITLE
Expand sensitive file detection patterns in PathSensitivityEnricher

### DIFF
--- a/crates/request-adaptor/src/enrichers/path_sensitivity.rs
+++ b/crates/request-adaptor/src/enrichers/path_sensitivity.rs
@@ -9,13 +9,7 @@ use duramen_engine::entities::{AuthzResource, ResourceType};
 /// - Keys and certificates (.pem, id_rsa)
 /// - IDE and Secret Managers (.vscode/settings.json, vault-token)
 /// - Infrastructure state files (*.tfstate)
-
-const SENSITIVE_PATTERNS: &[&str] = &[
-    ".env",
-    "secrets",
-    ".secret",
-    "credentials",
-];
+const SENSITIVE_PATTERNS: &[&str] = &[".env", "secrets", ".secret", "credentials"];
 
 const KEY_PATTERNS: &[&str] = &[
     ".pem",
@@ -28,12 +22,7 @@ const KEY_PATTERNS: &[&str] = &[
     ".gnupg/",
 ];
 
-const CLOUD_CONFIG_PATTERNS: &[&str] = &[
-    ".aws/",
-    ".azure/",
-    ".gcloud/",
-    ".kube/",
-];
+const CLOUD_CONFIG_PATTERNS: &[&str] = &[".aws/", ".azure/", ".gcloud/", ".kube/"];
 
 const AUTH_TOKEN_PATTERNS: &[&str] = &[
     ".npmrc",
@@ -48,16 +37,9 @@ const AUTH_TOKEN_PATTERNS: &[&str] = &[
     ".my.cnf",
 ];
 
-const HISTORY_PATTERNS: &[&str] = &[
-    ".bash_history",
-    ".zsh_history",
-    ".node_repl_history",
-];
+const HISTORY_PATTERNS: &[&str] = &[".bash_history", ".zsh_history", ".node_repl_history"];
 
-const IDE_PATTERNS: &[&str] = &[
-    ".vscode/settings.json",
-    ".idea/",
-];
+const IDE_PATTERNS: &[&str] = &[".vscode/settings.json", ".idea/"];
 
 const CI_PATTERNS: &[&str] = &[
     ".github/workflows/",
@@ -111,16 +93,30 @@ impl ResourceEnricher for PathSensitivityEnricher {
 
         let path = resource.id.to_lowercase();
 
-        let contains_sensitive = SENSITIVE_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
-            || KEY_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
-            || CLOUD_CONFIG_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
-            || AUTH_TOKEN_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
-            || HISTORY_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
-            || IDE_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
+        let contains_sensitive = SENSITIVE_PATTERNS
+            .iter()
+            .any(|p| path.contains(&p.to_lowercase()))
+            || KEY_PATTERNS
+                .iter()
+                .any(|p| path.contains(&p.to_lowercase()))
+            || CLOUD_CONFIG_PATTERNS
+                .iter()
+                .any(|p| path.contains(&p.to_lowercase()))
+            || AUTH_TOKEN_PATTERNS
+                .iter()
+                .any(|p| path.contains(&p.to_lowercase()))
+            || HISTORY_PATTERNS
+                .iter()
+                .any(|p| path.contains(&p.to_lowercase()))
+            || IDE_PATTERNS
+                .iter()
+                .any(|p| path.contains(&p.to_lowercase()))
             || CI_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()));
 
         let ends_with_sensitive = LOCK_FILES.iter().any(|f| path.ends_with(&f.to_lowercase()))
-            || SENSITIVE_EXTENSIONS.iter().any(|e| path.ends_with(&e.to_lowercase()));
+            || SENSITIVE_EXTENSIONS
+                .iter()
+                .any(|e| path.ends_with(&e.to_lowercase()));
 
         if contains_sensitive || ends_with_sensitive {
             if let Some(attrs) = resource.attributes.as_object_mut() {
@@ -155,7 +151,8 @@ mod tests {
         assert_eq!(
             resource.attributes.get("is_protected").unwrap(),
             &serde_json::json!(true),
-            "Failed to protect: {}", path
+            "Failed to protect: {}",
+            path
         );
     }
 
@@ -166,7 +163,8 @@ mod tests {
         enricher.enrich(&mut resource, &ctx());
         assert!(
             resource.attributes.get("is_protected").is_none(),
-            "Incorrectly protected: {}", path
+            "Incorrectly protected: {}",
+            path
         );
     }
 

--- a/crates/request-adaptor/src/enrichers/path_sensitivity.rs
+++ b/crates/request-adaptor/src/enrichers/path_sensitivity.rs
@@ -1,8 +1,23 @@
 use crate::pipeline::{PipelineContext, ResourceEnricher};
 use duramen_engine::entities::{AuthzResource, ResourceType};
 
+/// This file maintains lists of sensitive paths and files to flag as `is_protected` for CEDAR policies.
+/// Categories include:
+/// - Cloud configuration & credentials (.aws, .kube)
+/// - Auth tokens and git credentials (.npmrc, .git-credentials)
+/// - Shell histories (.bash_history)
+/// - Keys and certificates (.pem, id_rsa)
+/// - IDE and Secret Managers (.vscode/settings.json, vault-token)
+/// - Infrastructure state files (*.tfstate)
+
 const SENSITIVE_PATTERNS: &[&str] = &[
     ".env",
+    "secrets",
+    ".secret",
+    "credentials",
+];
+
+const KEY_PATTERNS: &[&str] = &[
     ".pem",
     ".key",
     ".p12",
@@ -10,9 +25,48 @@ const SENSITIVE_PATTERNS: &[&str] = &[
     ".ssh/",
     "id_rsa",
     "id_ed25519",
-    "secrets",
-    ".secret",
-    "credentials",
+    ".gnupg/",
+];
+
+const CLOUD_CONFIG_PATTERNS: &[&str] = &[
+    ".aws/",
+    ".azure/",
+    ".gcloud/",
+    ".kube/",
+];
+
+const AUTH_TOKEN_PATTERNS: &[&str] = &[
+    ".npmrc",
+    ".pypirc",
+    ".netrc",
+    ".docker/config.json",
+    ".git-credentials",
+    ".gitconfig",
+    ".vault-token",
+    "vault.hcl",
+    ".pgpass",
+    ".my.cnf",
+];
+
+const HISTORY_PATTERNS: &[&str] = &[
+    ".bash_history",
+    ".zsh_history",
+    ".node_repl_history",
+];
+
+const IDE_PATTERNS: &[&str] = &[
+    ".vscode/settings.json",
+    ".idea/",
+];
+
+const CI_PATTERNS: &[&str] = &[
+    ".github/workflows/",
+    ".github/actions/",
+    ".gitlab-ci.yml",
+    "Jenkinsfile",
+    ".circleci/",
+    ".azure-pipelines/",
+    "azure-pipelines.yml",
 ];
 
 const LOCK_FILES: &[&str] = &[
@@ -25,14 +79,15 @@ const LOCK_FILES: &[&str] = &[
     "go.sum",
 ];
 
-const CI_PATTERNS: &[&str] = &[
-    ".github/workflows/",
-    ".github/actions/",
-    ".gitlab-ci.yml",
-    "Jenkinsfile",
-    ".circleci/",
-    ".azure-pipelines/",
-    "azure-pipelines.yml",
+const SENSITIVE_EXTENSIONS: &[&str] = &[
+    ".tfstate",
+    ".tfvars",
+    ".jks",
+    ".keystore",
+    ".kubeconfig",
+    "kubeconfig", // Catches files named exactly 'kubeconfig'
+    ".crt",
+    ".cert",
 ];
 
 #[derive(Default)]
@@ -55,11 +110,19 @@ impl ResourceEnricher for PathSensitivityEnricher {
         }
 
         let path = resource.id.to_lowercase();
-        let is_sensitive = SENSITIVE_PATTERNS.iter().any(|p| path.contains(p))
-            || LOCK_FILES.iter().any(|f| path.ends_with(&f.to_lowercase()))
+
+        let contains_sensitive = SENSITIVE_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
+            || KEY_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
+            || CLOUD_CONFIG_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
+            || AUTH_TOKEN_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
+            || HISTORY_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
+            || IDE_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()))
             || CI_PATTERNS.iter().any(|p| path.contains(&p.to_lowercase()));
 
-        if is_sensitive {
+        let ends_with_sensitive = LOCK_FILES.iter().any(|f| path.ends_with(&f.to_lowercase()))
+            || SENSITIVE_EXTENSIONS.iter().any(|e| path.ends_with(&e.to_lowercase()));
+
+        if contains_sensitive || ends_with_sensitive {
             if let Some(attrs) = resource.attributes.as_object_mut() {
                 attrs.insert("is_protected".into(), serde_json::Value::Bool(true));
             }
@@ -84,61 +147,91 @@ mod tests {
         }
     }
 
-    #[test]
-    fn marks_env_file_as_protected() {
+    fn assert_is_protected(path: &str) {
         let enricher = PathSensitivityEnricher::new();
-        let mut resource = AuthzResource::file("/project/.env");
+        let mut resource = AuthzResource::file(path);
         resource.attributes = serde_json::json!({});
         enricher.enrich(&mut resource, &ctx());
         assert_eq!(
             resource.attributes.get("is_protected").unwrap(),
-            &serde_json::json!(true)
+            &serde_json::json!(true),
+            "Failed to protect: {}", path
         );
+    }
+
+    fn assert_not_protected(path: &str) {
+        let enricher = PathSensitivityEnricher::new();
+        let mut resource = AuthzResource::file(path);
+        resource.attributes = serde_json::json!({});
+        enricher.enrich(&mut resource, &ctx());
+        assert!(
+            resource.attributes.get("is_protected").is_none(),
+            "Incorrectly protected: {}", path
+        );
+    }
+
+    #[test]
+    fn marks_env_file_as_protected() {
+        assert_is_protected("/project/.env");
     }
 
     #[test]
     fn marks_ssh_key_as_protected() {
-        let enricher = PathSensitivityEnricher::new();
-        let mut resource = AuthzResource::file("/home/user/.ssh/id_rsa");
-        resource.attributes = serde_json::json!({});
-        enricher.enrich(&mut resource, &ctx());
-        assert_eq!(
-            resource.attributes.get("is_protected").unwrap(),
-            &serde_json::json!(true)
-        );
+        assert_is_protected("/home/user/.ssh/id_rsa");
+        assert_is_protected("/home/user/.gnupg/pubring.kbx");
+    }
+
+    #[test]
+    fn marks_cloud_config_as_protected() {
+        assert_is_protected("/home/user/.aws/credentials");
+        assert_is_protected("/home/user/.azure/accessTokens.json");
+        assert_is_protected("/home/user/.kube/config");
+    }
+
+    #[test]
+    fn marks_auth_tokens_as_protected() {
+        assert_is_protected("/app/.npmrc");
+        assert_is_protected("/home/user/.docker/config.json");
+        assert_is_protected("/var/lib/.git-credentials");
+        assert_is_protected("/home/user/.vault-token");
+    }
+
+    #[test]
+    fn marks_history_files_as_protected() {
+        assert_is_protected("/home/user/.bash_history");
+        assert_is_protected("/home/user/.zsh_history");
+    }
+
+    #[test]
+    fn marks_ide_secrets_as_protected() {
+        assert_is_protected("/project/.vscode/settings.json");
+        assert_is_protected("/project/.idea/workspace.xml");
+    }
+
+    #[test]
+    fn marks_sensitive_extensions_as_protected() {
+        assert_is_protected("/infra/prod.tfstate");
+        assert_is_protected("/infra/variables.tfvars");
+        assert_is_protected("/etc/ssl/certs/server.crt");
+        assert_is_protected("/app/security/keystore.jks");
+        assert_is_protected("/home/user/mycluster.kubeconfig");
     }
 
     #[test]
     fn marks_ci_config_as_protected() {
-        let enricher = PathSensitivityEnricher::new();
-        let mut resource = AuthzResource::file("/project/.github/workflows/ci.yml");
-        resource.attributes = serde_json::json!({});
-        enricher.enrich(&mut resource, &ctx());
-        assert_eq!(
-            resource.attributes.get("is_protected").unwrap(),
-            &serde_json::json!(true)
-        );
+        assert_is_protected("/project/.github/workflows/ci.yml");
     }
 
     #[test]
     fn marks_lock_file_as_protected() {
-        let enricher = PathSensitivityEnricher::new();
-        let mut resource = AuthzResource::file("/project/Cargo.lock");
-        resource.attributes = serde_json::json!({});
-        enricher.enrich(&mut resource, &ctx());
-        assert_eq!(
-            resource.attributes.get("is_protected").unwrap(),
-            &serde_json::json!(true)
-        );
+        assert_is_protected("/project/Cargo.lock");
     }
 
     #[test]
     fn skips_normal_files() {
-        let enricher = PathSensitivityEnricher::new();
-        let mut resource = AuthzResource::file("/project/src/main.rs");
-        resource.attributes = serde_json::json!({});
-        enricher.enrich(&mut resource, &ctx());
-        assert!(resource.attributes.get("is_protected").is_none());
+        assert_not_protected("/project/src/main.rs");
+        assert_not_protected("/project/README.md");
+        assert_not_protected("/app/public/index.html");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This pull request improves the security coverage of the `PathSensitivityEnricher` significantly by expanding the list of files flagged as `is_protected`. It addresses a blind spot where a malicious or compromised AI agent could bypass CEDAR policies by targeting high-value sensitive files (such as cloud credentials, auth tokens, or infrastructure state) that were missing from the original, narrow detection list.

## Changes
- **Expanded Pattern Categories:** Replaced the single `SENSITIVE_PATTERNS` array with categorized, maintainable lists: `KEY_PATTERNS`, `CLOUD_CONFIG_PATTERNS`, `AUTH_TOKEN_PATTERNS`, `HISTORY_PATTERNS`, and `IDE_PATTERNS`.
- **Added Extension-Based Matching:** Introduced `SENSITIVE_EXTENSIONS` to accurately catch files by extension (e.g., `.tfstate`, `.tfvars`, `.kubeconfig`, `.jks`) via `ends_with()` logic, rather than relying solely on substring matches.
- **Updated Enrichment Logic:** Refactored the `enrich` function to efficiently evaluate target paths against the new categorization arrays using combined `.any()` iterators.
- **Improved Test Coverage:** Refactored the test suite to use `assert_is_protected` and `assert_not_protected` helper macros, adding dedicated unit tests for cloud configs, auth tokens, history files, IDE secrets, and sensitive extensions.

## Why
Security policies in Duramen that rely on `when { resource.is_protected == true }` effectively fail-open if the enricher's underlying detection list is incomplete. Because AI agents (MCPs) can execute commands and read local files, an attacker could easily instruct the agent to exfiltrate `~/.aws/credentials` or `terraform.tfstate`, files that the previous implementation ignored. By strictly categorizing and comprehensively checking for standard development, cloud, and CI/CD secrets, we close these blind spots and ensure malicious MCPs cannot trivially bypass file-access restrictions.

## Verification
- **Verified Standard Coverage:** Confirmed via test suite that previously caught files (`.env`, `.ssh/id_rsa`, `Cargo.lock`) are still correctly marked as `is_protected`.
- **Verified New Categories:** Simulated resource access to new targets (`~/.aws/credentials`, `.npmrc`, `.bash_history`, `.vscode/settings.json`). Confirmed the enricher successfully intercepts and flags them.
- **Verified Extension Matching:** Validated that files ending in specific sensitive extensions (`prod.tfstate`, `mycluster.kubeconfig`) trigger protection, while similarly named but safe files do not.
- **Verified False Positives:** Checked standard source code files (`main.rs`, `README.md`) to ensure the expanded heuristics do not inadvertently flag normal project files.